### PR TITLE
Fix the crashes

### DIFF
--- a/main.go
+++ b/main.go
@@ -1,12 +1,21 @@
 package main
 
 import "tic80-go/tic80"
+import _ "unsafe"
 
 var (
 	t int = 0
 	x int = 96
 	y int = 24
 )
+
+//go:linkname start _start
+func start()
+
+//go:export BOOT
+func boot() {
+	start()
+}
 
 //go:export TIC
 func main() {

--- a/target.json
+++ b/target.json
@@ -20,8 +20,7 @@
 	"--initial-memory=262144",
 	"--max-memory=262144",
 	"--no-entry",
-	"--stack-first",
-	"-z stack-size=65536",
+	"-zstack-size=65536",
 	"--strip-all"
   ],
   "emulator": "w4 run",

--- a/tic80/tic80.go
+++ b/tic80/tic80.go
@@ -848,3 +848,6 @@ func Trib(x0, y0, x1, y1, x2, y2, color int) {
 
 //go:export tstamp
 func Tstamp() uint32
+
+//go:export main.main
+func main() {}


### PR DESCRIPTION
Created a BOOT callback that calls Go's `_start` function, so that the heap is initialised, and removed `--stack-first` as it was causing memory corruption.